### PR TITLE
Manually escaping default translations for CVE-2020-15169

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and releases in blacklight project adheres to [Semantic Versioning](http://semve
 
 ## [Unreleased]
 
+### Security
+-  manually escaping default translations for [CVE-2020-15169](https://groups.google.com/forum/#!topic/rubyonrails-security/b-C9kSGXYrc)
+
 ### Fixed
 - 'more' link to view modal isn't working [1659](https://github.com/ualbertalib/discovery/issues/1659)
 

--- a/README.md
+++ b/README.md
@@ -40,5 +40,9 @@ rails generate blacklight:install
 
 In addition, you must have the Bundler and Rails 4.0 gems installed. Other gem dependencies are defined in the blacklight.gemspec file and will be automatically loaded by Bundler.
 
+Specify the version of rails `export RAILS_VERSION=4.2.11.3`
+Install a compatable bundler `gem install bundler -v 1.17.3`
+Use compatable bundler `bundle _1.17.3_ install`
+
 ## Configuring Apache Solr 
 You'll also want some information about how Blacklight expects [Apache Solr](http://lucene.apache.org/solr ) to run, which you can find in [README_SOLR](https://github.com/projectblacklight/blacklight/wiki/README_SOLR)

--- a/app/helpers/blacklight/component_helper_behavior.rb
+++ b/app/helpers/blacklight/component_helper_behavior.rb
@@ -2,7 +2,7 @@ module Blacklight
   module ComponentHelperBehavior
 
     def document_action_label action, opts
-      t("blacklight.tools.#{action}", default: opts.label || action.to_s.humanize)
+      t("blacklight.tools.#{action}", default: h(opts.label || action.to_s.humanize))
     end
 
     def document_action_path action_opts, url_opts = nil

--- a/app/helpers/blacklight/configuration_helper_behavior.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior.rb
@@ -66,7 +66,7 @@ module Blacklight::ConfigurationHelperBehavior
       :"blacklight.search.fields.index.#{field}",
       :"blacklight.search.fields.#{field}",
       (field_config.label if field_config),
-      field.to_s.humanize
+      h(field.to_s.humanize)
     )
   end
 
@@ -79,7 +79,7 @@ module Blacklight::ConfigurationHelperBehavior
       :"blacklight.search.fields.show.#{field}",
       :"blacklight.search.fields.#{field}",
       (field_config.label if field_config),
-      field.to_s.humanize
+      h(field.to_s.humanize)
     )
   end
 
@@ -89,7 +89,7 @@ module Blacklight::ConfigurationHelperBehavior
     field_config = blacklight_config.facet_fields[field]
     defaults = [:"blacklight.search.fields.facet.#{field}", :"blacklight.search.fields.#{field}"]
     defaults << field_config.label if field_config
-    defaults << field.to_s.humanize
+    defaults << h(field.to_s.humanize)
 
     field_label *defaults
   end
@@ -101,7 +101,7 @@ module Blacklight::ConfigurationHelperBehavior
       :"blacklight.search.view.#{view}",
       view_config.label,
       view_config.title,
-      view.to_s.humanize
+      h(view.to_s.humanize)
     )
   end
 
@@ -120,6 +120,7 @@ module Blacklight::ConfigurationHelperBehavior
   def field_label *i18n_keys
     first, *rest = i18n_keys.compact
 
+    # re: CVE-2020-15169 need to target just the user input see calling methods
     t(first, default: rest)
   end
   alias_method :solr_field_label, :field_label


### PR DESCRIPTION
We're not going to get upstream updates for Rails 4.2 have to use the workaround. I also added some documentation about the dependencies.  

### Impact

When an HTML-unsafe string is passed as the default for a missing translation key [named `html` or ending in `_html`](https://guides.rubyonrails.org/i18n.html#using-safe-html-translations), the default string is incorrectly marked as HTML-safe and not escaped. Vulnerable code may look like the following examples:

```erb
<%# The welcome_html translation is not defined for the current locale: %>
<%= t("welcome_html", default: untrusted_user_controlled_string) %>

<%# Neither the title.html translation nor the missing.html translation is defined for the current locale: %>
<%= t("title.html", default: [:"missing.html", untrusted_user_controlled_string]) %>
```

### Workarounds

Impacted users who can’t upgrade to a patched Rails version can avoid this issue by manually escaping default translations with the `html_escape` helper (aliased as `h`):

```erb
<%= t("welcome_html", default: h(untrusted_user_controlled_string)) %>
```