### PR TITLE
comment out all deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ and releases in blacklight project adheres to [Semantic Versioning](http://semve
 
 ### Changed
 - Upgrade to Bootstrap 4 [#1](https://github.com/ualbertalib/blacklight/issues/1)
+- Commented out all deprecation warnings [1958](https://github.com/ualbertalib/discovery/issues/1958)

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -264,7 +264,7 @@ module Blacklight::BlacklightHelperBehavior
     tag_or_document = args.first
 
     if tag_or_document.is_a? String or tag_or_document.is_a? Symbol
-      Deprecation.warn(Blacklight::BlacklightHelperBehavior, "#render_document_heading with a tag argument is deprecated; pass e.g. `tag: :h4` instead")
+      # Deprecation.warn(Blacklight::BlacklightHelperBehavior, "#render_document_heading with a tag argument is deprecated; pass e.g. `tag: :h4` instead")
       tag = tag_or_document
       document = @document
     else
@@ -347,7 +347,7 @@ module Blacklight::BlacklightHelperBehavior
   # @param [Symbol, Proc, String] field Render the given field or evaluate the proc or render the given string
   def render_document_index_label doc, field, opts = {}
     if field.is_a? Hash
-      Deprecation.warn self, "Calling render_document_index_label with a hash is deprecated"
+      # Deprecation.warn self, "Calling render_document_index_label with a hash is deprecated"
       field = field[:label]
     end
     presenter(doc).render_document_index_label field, opts

--- a/app/helpers/blacklight/render_partials_helper.rb
+++ b/app/helpers/blacklight/render_partials_helper.rb
@@ -40,7 +40,7 @@ module Blacklight::RenderPartialsHelper
   # @param [Hash] locales to pass through to the partials
   def render_document_partial(doc, base_name, locals = {})
     format = if method(:document_partial_name).arity == 1
-      Deprecation.warn self, "The #document_partial_name with a single argument is deprecated. Update your override to include a second argument for the 'base name'"
+      # Deprecation.warn self, "The #document_partial_name with a single argument is deprecated. Update your override to include a second argument for the 'base name'"
       document_partial_name(doc)
     else
       document_partial_name(doc, base_name)

--- a/app/helpers/blacklight/url_helper_behavior.rb
+++ b/app/helpers/blacklight/url_helper_behavior.rb
@@ -30,7 +30,7 @@ module Blacklight::UrlHelperBehavior
     if field_or_opts.is_a? Hash
       opts = field_or_opts
       if opts[:label]
-        Deprecation.warn self, "The second argument to link_to_document should now be the label."
+        # Deprecation.warn self, "The second argument to link_to_document should now be the label."
         field = opts.delete(:label)
       end
     else
@@ -301,11 +301,11 @@ module Blacklight::UrlHelperBehavior
   # This method should move to BlacklightMarc in Blacklight 6.x
   def refworks_export_url params = {}
     if params.is_a? ::SolrDocument or (params.nil? and instance_variable_defined? :@document)
-      Deprecation.warn self, "Calling #refworks_export_url without a :url is deprecated. Pass in e.g. { url: url_for_document(@document, format: :refworks_marc_txt) } instead"
+      # Deprecation.warn self, "Calling #refworks_export_url without a :url is deprecated. Pass in e.g. { url: url_for_document(@document, format: :refworks_marc_txt) } instead"
       url = url_for_document(params || @document)
       params = { url: polymorphic_url(url, format: :refworks_marc_txt, only_path: false) }
     elsif params[:id]
-      Deprecation.warn self, "Calling #refworks_export_url without a :url is deprecated. Pass in e.g. { url: url_for_document(@document, format: :refworks_marc_txt) } instead"
+      # Deprecation.warn self, "Calling #refworks_export_url without a :url is deprecated. Pass in e.g. { url: url_for_document(@document, format: :refworks_marc_txt) } instead"
       params = { url: polymorphic_url(url_for_document(params), format: :refworks_marc_txt, only_path: false) }
     end
 

--- a/app/views/catalog/email_sent.html.erb
+++ b/app/views/catalog/email_sent.html.erb
@@ -1,2 +1,2 @@
-<% Deprecation.warn controller, "The template catalog/email_sent.html.erb is deprecated; use email_success instead" %>
+<% # Deprecation.warn controller, "The template catalog/email_sent.html.erb is deprecated; use email_success instead" %>
 <%= render template: "catalog/email_success" %>

--- a/app/views/catalog/sms_sent.html.erb
+++ b/app/views/catalog/sms_sent.html.erb
@@ -1,2 +1,2 @@
-<% Deprecation.warn controller, "The template catalog/sms_sent.html.erb is deprecated; use sms_success instead" %>
+<% # Deprecation.warn controller, "The template catalog/sms_sent.html.erb is deprecated; use sms_success instead" %>
 <%= render template: "catalog/sms_success" %>

--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -65,7 +65,7 @@ module Blacklight
   end
 
   def self.solr
-    Deprecation.warn Blacklight, "Blacklight.solr is deprecated and will be removed in 6.0.0. Use Blacklight.default_index.connection instead", caller
+    # Deprecation.warn Blacklight, "Blacklight.solr is deprecated and will be removed in 6.0.0. Use Blacklight.default_index.connection instead", caller
     default_index.connection
   end
 
@@ -74,7 +74,7 @@ module Blacklight
   end
 
   def self.solr_config
-    Deprecation.warn Blacklight, "Blacklight.solr_config is deprecated and will be removed in 6.0.0. Use Blacklight.connection_config instead", caller
+    # Deprecation.warn Blacklight, "Blacklight.solr_config is deprecated and will be removed in 6.0.0. Use Blacklight.connection_config instead", caller
     connection_config
   end
 
@@ -92,7 +92,7 @@ module Blacklight
     return @blacklight_yml if @blacklight_yml
     unless File.exists?(blacklight_config_file)
       if File.exists?(solr_file)
-        Deprecation.warn Blacklight, "Configuration is now done via blacklight.yml. Suppport for solr.yml will be removed in blacklight 6.0.0"
+        # Deprecation.warn Blacklight, "Configuration is now done via blacklight.yml. Suppport for solr.yml will be removed in blacklight 6.0.0"
         return solr_yml
       else
         raise "You are missing a configuration file: #{blacklight_config_file}. Have you run \"rails generate blacklight:install\"?"

--- a/lib/blacklight/configuration.rb
+++ b/lib/blacklight/configuration.rb
@@ -231,7 +231,7 @@ module Blacklight
       raise e if Object.const_defined? "::SearchBuilder"
 
       # Otherwise the NameError was a result of not being able to find SearchBuilder
-      Deprecation.warn(Configuration, "Your application is missing the SearchBuilder. Have you run `rails generate blacklight:search_builder`? Falling back to Blacklight::Solr::SearchBuilder")
+      # Deprecation.warn(Configuration, "Your application is missing the SearchBuilder. Have you run `rails generate blacklight:search_builder`? Falling back to Blacklight::Solr::SearchBuilder")
       Blacklight::Solr::SearchBuilder
     end
 

--- a/lib/blacklight/configuration/solr_field.rb
+++ b/lib/blacklight/configuration/solr_field.rb
@@ -1,7 +1,7 @@
 module Blacklight
   class Configuration::SolrField < Blacklight::Configuration::Field
     def self.extended *args
-      Deprecation.warn Blacklight::Configuration::SolrField, "Blacklight::Configuration::SolrField is deprecated; use Blacklight::Configuration::Field instead"
+      # Deprecation.warn Blacklight::Configuration::SolrField, "Blacklight::Configuration::SolrField is deprecated; use Blacklight::Configuration::Field instead"
     end
   end
 end

--- a/lib/blacklight/configuration/view_config.rb
+++ b/lib/blacklight/configuration/view_config.rb
@@ -7,34 +7,34 @@ class Blacklight::Configuration
       self.deprecation_horizon = 'blacklight 6.0'
 
       def html_title
-        Deprecation.warn(self.class, "config.show.html_title is deprecated; use config.show.title_field instead")
+        # Deprecation.warn(self.class, "config.show.html_title is deprecated; use config.show.title_field instead")
         fetch(:html_title, title_field)
       end
 
       def heading
-        Deprecation.warn(self.class, "config.show.heading is deprecated; use config.show.title_field instead")
+        # Deprecation.warn(self.class, "config.show.heading is deprecated; use config.show.title_field instead")
         fetch(:heading, title_field)
       end
 
       def display_type
-        Deprecation.warn(self.class, "config.show.display_type is deprecated; use config.show.display_type_field instead")
+        # Deprecation.warn(self.class, "config.show.display_type is deprecated; use config.show.display_type_field instead")
         fetch(:display_type, display_type_field)
       end
 
       def html_title= value
-        Deprecation.warn(self.class, "config.show.html_title is deprecated; use config.show.title_field instead")
+        # Deprecation.warn(self.class, "config.show.html_title is deprecated; use config.show.title_field instead")
         super value
         self.title_field = value
       end
 
       def heading= value
-        Deprecation.warn(self.class, "config.show.heading is deprecated; use config.show.title_field instead")
+        # Deprecation.warn(self.class, "config.show.heading is deprecated; use config.show.title_field instead")
         super value
         self.title_field = value
       end
 
       def display_type= value
-        Deprecation.warn(self.class, "config.show.display_type is deprecated; use config.show.display_type_field instead")
+        # Deprecation.warn(self.class, "config.show.display_type is deprecated; use config.show.display_type_field instead")
         super value
         self.display_type_field = value
       end
@@ -45,23 +45,23 @@ class Blacklight::Configuration
       self.deprecation_horizon = 'blacklight 6.0'
 
       def record_display_type
-        Deprecation.warn(self.class, "config.index.record_display_type is deprecated; use config.index.display_type_field instead")
+        # Deprecation.warn(self.class, "config.index.record_display_type is deprecated; use config.index.display_type_field instead")
         fetch(:record_display_type, display_type_field)
       end
 
       def record_display_type= value
-        Deprecation.warn(self.class, "config.index.record_display_type is deprecated; use config.index.display_type_field instead")
+        # Deprecation.warn(self.class, "config.index.record_display_type is deprecated; use config.index.display_type_field instead")
         super value
         self.display_type_field = value
       end
 
       def show_link
-        Deprecation.warn(self.class, "config.index.show_link is deprecated; use config.index.title_field instead")   
+        # Deprecation.warn(self.class, "config.index.show_link is deprecated; use config.index.title_field instead")   
         fetch(:show_link, title_field)
       end
 
       def show_link= value
-        Deprecation.warn(self.class, "config.index.show_link is deprecated; use config.index.title_field instead")
+        # Deprecation.warn(self.class, "config.index.show_link is deprecated; use config.index.title_field instead")
         super value
         self.title_field = value
       end

--- a/lib/blacklight/document.rb
+++ b/lib/blacklight/document.rb
@@ -103,7 +103,7 @@ module Blacklight::Document
     val = fetch(key, opts[:default])
 
     if val.is_a?(Array) and opts[:sep]
-      Deprecation.warn(Blacklight::Solr::Document, "#{self.class}#get with a :sep option is deprecated; use #[] or #fetch and join the values using e.g. Array#to_sentence") unless opts[:sep].nil?
+      # Deprecation.warn(Blacklight::Solr::Document, "#{self.class}#get with a :sep option is deprecated; use #[] or #fetch and join the values using e.g. Array#to_sentence") unless opts[:sep].nil?
       val.join(opts[:sep])
     else
       val

--- a/lib/blacklight/document_presenter.rb
+++ b/lib/blacklight/document_presenter.rb
@@ -100,7 +100,7 @@ module Blacklight
     # @param [Symbol, Proc, String] field Render the given field or evaluate the proc or render the given string
     def render_document_index_label field, opts ={}
       if field.is_a? Hash
-        Deprecation.warn DocumentPresenter, "Calling render_document_index_label with a hash is deprecated"
+        # Deprecation.warn DocumentPresenter, "Calling render_document_index_label with a hash is deprecated"
         field = field[:label]
       end
       label = case field

--- a/lib/blacklight/request_builders.rb
+++ b/lib/blacklight/request_builders.rb
@@ -120,7 +120,7 @@ module Blacklight
     # Opensearch autocomplete parameters for plucking a field's value from the results
     def solr_opensearch_params(field=nil)
       if field.nil?
-        Deprecation.warn(Blacklight::RequestBuilders, "Calling Blacklight::RequestBuilders#solr_opensearch_params without a field name is deprecated and will be required in Blacklight 6.0.")
+        # Deprecation.warn(Blacklight::RequestBuilders, "Calling Blacklight::RequestBuilders#solr_opensearch_params without a field name is deprecated and will be required in Blacklight 6.0.")
       end
 
       solr_params = {}

--- a/lib/blacklight/search_builder.rb
+++ b/lib/blacklight/search_builder.rb
@@ -104,7 +104,7 @@ module Blacklight
     # @return [Blacklight::SolrResponse] the solr response object
     def to_hash method_extra_params = nil
       unless method_extra_params.nil?
-        Deprecation.warn(Blacklight::SearchBuilder, "Calling SearchBuilder#query with extra parameters is deprecated. Use #merge(Hash) instead")
+        # Deprecation.warn(Blacklight::SearchBuilder, "Calling SearchBuilder#query with extra parameters is deprecated. Use #merge(Hash) instead")
         merge(method_extra_params)
       end
 
@@ -140,7 +140,7 @@ module Blacklight
       request.tap do |request_parameters|
         processor_chain.each do |method_name|
           if scope.respond_to?(method_name, true)
-            Deprecation.warn Blacklight::SearchBuilder, "Building search parameters by calling #{method_name} on #{scope.class}. This behavior will be deprecated in Blacklight 6.0. Instead, define #{method_name} on a subclass of #{self.class} and set search_builder_class in the configuration"
+            # Deprecation.warn Blacklight::SearchBuilder, "Building search parameters by calling #{method_name} on #{scope.class}. This behavior will be deprecated in Blacklight 6.0. Instead, define #{method_name} on a subclass of #{self.class} and set search_builder_class in the configuration"
             scope.send(method_name, request_parameters, blacklight_params)
           else
             send(method_name, request_parameters)

--- a/lib/blacklight/search_helper.rb
+++ b/lib/blacklight/search_helper.rb
@@ -135,7 +135,7 @@ module Blacklight::SearchHelper
       fetch_many(id, params, extra_controller_params)
     else
       if id.nil?
-        Deprecation.warn Blacklight::SearchHelper, "Calling #fetch without an explicit id argument is deprecated and will be removed in Blacklight 6.0"
+        # Deprecation.warn Blacklight::SearchHelper, "Calling #fetch without an explicit id argument is deprecated and will be removed in Blacklight 6.0"
         id ||= params[:id]
       end
       fetch_one(id, extra_controller_params)
@@ -265,7 +265,7 @@ module Blacklight::SearchHelper
     # @overload fetch_many(ids, user_params, extra_controller_params)
     def fetch_many(ids=[], *args)
       if args.length == 1
-        Deprecation.warn(Blacklight::SearchHelper, "fetch_many with 2 arguments is deprecated")
+        # Deprecation.warn(Blacklight::SearchHelper, "fetch_many with 2 arguments is deprecated")
         user_params = params
         extra_controller_params = args.first || {}
       else
@@ -293,7 +293,7 @@ module Blacklight::SearchHelper
       end
 
       if default_solr_doc_params(id) != old_solr_doc_params
-        Deprecation.warn Blacklight::SearchHelper, "The #solr_doc_params method is deprecated. Instead, you should provide a custom SolrRepository implementation for the additional behavior you're offering. The current behavior will be removed in Blacklight 6.0"
+        # Deprecation.warn Blacklight::SearchHelper, "The #solr_doc_params method is deprecated. Instead, you should provide a custom SolrRepository implementation for the additional behavior you're offering. The current behavior will be removed in Blacklight 6.0"
         extra_controller_params = extra_controller_params.merge(old_solr_doc_params)
       end
 

--- a/lib/blacklight/solr/document/dublin_core.rb
+++ b/lib/blacklight/solr/document/dublin_core.rb
@@ -2,6 +2,6 @@ module Blacklight::Solr::Document::DublinCore
   include Blacklight::Document::DublinCore
 
   def self.extended(document)
-    Deprecation.warn Blacklight::Solr::Document::DublinCore, "Blacklight::Solr::Document::DublinCore is deprecated; use Blacklight::Document::DublinCore instead."
+    # Deprecation.warn Blacklight::Solr::Document::DublinCore, "Blacklight::Solr::Document::DublinCore is deprecated; use Blacklight::Document::DublinCore instead."
   end
 end

--- a/lib/blacklight/solr/document/email.rb
+++ b/lib/blacklight/solr/document/email.rb
@@ -2,6 +2,6 @@ module Blacklight::Solr::Document::Email
   include Blacklight::Document::Email
   
   def self.extended(document)
-    Deprecation.warn Blacklight::Solr::Document::Email, "Blacklight::Solr::Document::Email is deprecated; use Blacklight::Document::Email instead."
+    # Deprecation.warn Blacklight::Solr::Document::Email, "Blacklight::Solr::Document::Email is deprecated; use Blacklight::Document::Email instead."
   end
 end

--- a/lib/blacklight/solr/document/export.rb
+++ b/lib/blacklight/solr/document/export.rb
@@ -2,6 +2,6 @@ module Blacklight::Solr::Document::Export
   include Blacklight::Document::Export
   
   def self.extended(document)
-    Deprecation.warn Blacklight::Solr::Document::Export, "Blacklight::Solr::Document::Export is deprecated; use Blacklight::Document::Export instead."
+    # Deprecation.warn Blacklight::Solr::Document::Export, "Blacklight::Solr::Document::Export is deprecated; use Blacklight::Document::Export instead."
   end
 end

--- a/lib/blacklight/solr/document/extensions.rb
+++ b/lib/blacklight/solr/document/extensions.rb
@@ -3,6 +3,6 @@ module Blacklight::Solr::Document::Extensions
   include Blacklight::Document::Extensions
   
   def self.extended(document)
-    Deprecation.warn Blacklight::Solr::Document::Extensions, "Blacklight::Solr::Document::Extensions is deprecated; use Blacklight::Document::Extensions instead."
+    # Deprecation.warn Blacklight::Solr::Document::Extensions, "Blacklight::Solr::Document::Extensions is deprecated; use Blacklight::Document::Extensions instead."
   end
 end

--- a/lib/blacklight/solr/document/schema_org.rb
+++ b/lib/blacklight/solr/document/schema_org.rb
@@ -2,6 +2,6 @@ module Blacklight::Solr::Document::SchemaOrg
   include Blacklight::Document::SchemaOrg
   
   def self.extended(document)
-    Deprecation.warn Blacklight::Solr::Document::SchemaOrg, "Blacklight::Solr::Document::SchemaOrg is deprecated; use Blacklight::Document::SchemaOrg instead."
+    # Deprecation.warn Blacklight::Solr::Document::SchemaOrg, "Blacklight::Solr::Document::SchemaOrg is deprecated; use Blacklight::Document::SchemaOrg instead."
   end
 end

--- a/lib/blacklight/solr/document/sms.rb
+++ b/lib/blacklight/solr/document/sms.rb
@@ -2,6 +2,6 @@ module Blacklight::Solr::Document::Sms
   include Blacklight::Document::Sms
   
   def self.extended(document)
-    Deprecation.warn Blacklight::Solr::Document::Sms, "Blacklight::Solr::Document::Sms is deprecated; use Blacklight::Document::Sms instead."
+    # Deprecation.warn Blacklight::Solr::Document::Sms, "Blacklight::Solr::Document::Sms is deprecated; use Blacklight::Document::Sms instead."
   end
 end

--- a/lib/blacklight/solr_helper.rb
+++ b/lib/blacklight/solr_helper.rb
@@ -3,7 +3,7 @@ module Blacklight
     extend ActiveSupport::Concern
     included do
       include Blacklight::SearchHelper
-      Deprecation.warn Blacklight::SolrHelper, "Blacklight::SolrHelper is deprecated; use Blacklight::SearchHelper instead"
+      # Deprecation.warn Blacklight::SolrHelper, "Blacklight::SolrHelper is deprecated; use Blacklight::SearchHelper instead"
     end
   end
 end

--- a/lib/blacklight/solr_repository.rb
+++ b/lib/blacklight/solr_repository.rb
@@ -1,7 +1,7 @@
 module Blacklight
   class SolrRepository < AbstractRepository
     unless defined? RSolr
-      Deprecation.warn self, "RSolr should be in your gemfile. Blacklight 6.0 will not load rsolr by default"
+      # Deprecation.warn self, "RSolr should be in your gemfile. Blacklight 6.0 will not load rsolr by default"
       require 'rsolr'
     end
 

--- a/lib/railties/blacklight.rake
+++ b/lib/railties/blacklight.rake
@@ -22,7 +22,7 @@ namespace :blacklight do
 
   namespace :solr do
     task :seed do
-      Deprecation.warn Blacklight, "blacklight:solr:seed is deprecated; use blacklight:index:seed instead"
+      # Deprecation.warn Blacklight, "blacklight:solr:seed is deprecated; use blacklight:index:seed instead"
       Rake::Task['blacklight:index:seed'].invoke
     end
   end


### PR DESCRIPTION
We've forked and pinned our blacklight dependencies. Now we can remove all the Deprecation Warnings that are cluttering our logs and making them unreadable/unactionable.